### PR TITLE
Bump minimal required Ruby from 2.5->3.2

### DIFF
--- a/bolt.gemspec
+++ b/bolt.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 3.2"
 
   spec.add_dependency "addressable", '~> 2.5'
   spec.add_dependency "aws-sdk-ec2", '~> 1'


### PR DESCRIPTION
3.2 is the oldest and still maintained Ruby version.
