### PR TITLE
Rename gem to openbolt

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,40 @@
+---
+# https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+
+changelog:
+  exclude:
+    labels:
+      - duplicate
+      - invalid
+      - modulesync
+      - question
+      - skip-changelog
+      - wont-fix
+      - wontfix
+      - github_actions
+
+  categories:
+    - title: Breaking Changes 🛠
+      labels:
+        - backwards-incompatible
+
+    - title: New Features 🎉
+      labels:
+        - enhancement
+
+    - title: Bug Fixes 🐛
+      labels:
+        - bug
+
+    - title: Documentation Updates 📚
+      labels:
+        - documentation
+        - docs
+
+    - title: Dependency Updates ⬆️
+      labels:
+        - dependencies
+
+    - title: Other Changes
+      labels:
+        - "*"

--- a/.github/workflows/gem_release.yaml
+++ b/.github/workflows/gem_release.yaml
@@ -1,0 +1,106 @@
+---
+name: Gem Release
+
+on:
+  push:
+    tags:
+      - '*'
+
+permissions: {}
+
+jobs:
+  build-release:
+    # Prevent releases from forked repositories
+    if: github.repository_owner == 'OpenVoxProject'
+    name: Build the gem
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'ruby'
+      - name: Build gem
+        shell: bash
+        run: gem build --verbose *.gemspec
+      - name: Upload gem to GitHub cache
+        uses: actions/upload-artifact@v4
+        with:
+          name: gem-artifact
+          path: '*.gem'
+          retention-days: 1
+          compression-level: 0
+
+  create-github-release:
+    needs: build-release
+    name: Create GitHub release
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write # clone repo and create release
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Create Release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh release create --repo ${{ github.repository }} ${{ github.ref_name }} --generate-notes *.gem
+
+  release-to-github:
+    needs: build-release
+    name: Release to GitHub
+    runs-on: ubuntu-24.04
+    permissions:
+      packages: write # publish to rubygems.pkg.github.com
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Publish gem to GitHub packages
+        run: gem push --host https://rubygems.pkg.github.com/${{ github.repository_owner }} *.gem
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+
+  release-to-rubygems:
+    needs: build-release
+    name: Release gem to rubygems.org
+    runs-on: ubuntu-24.04
+    environment: release # recommended by rubygems.org
+    permissions:
+      id-token: write # rubygems.org authentication
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - uses: rubygems/configure-rubygems-credentials@v1.0.0
+      - name: Publish gem to rubygems.org
+        shell: bash
+        run: gem push *.gem
+
+  release-verification:
+    name: Check that all releases are done
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read # minimal permissions that we have to grant
+    needs:
+      - create-github-release
+      - release-to-github
+      - release-to-rubygems
+    steps:
+      - name: Download gem from GitHub cache
+        uses: actions/download-artifact@v4
+        with:
+          name: gem-artifact
+      - name: Install Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: 'ruby'
+      - name: Wait for release to propagate
+        shell: bash
+        run: |
+          gem install rubygems-await
+          gem await *.gem

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,0 +1,28 @@
+name: 'Prepare Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to be released.'
+        required: false
+        default: ''
+        type: string
+      base-branch:
+        description: 'The branch that will be used as the origin for the release branch.'
+        required: false
+        default: ''
+        type: string
+
+permissions: {}
+
+jobs:
+  prepare_release:
+    uses: OpenVoxProject/shared-actions/.github/workflows/prepare_release.yml@main
+    with:
+      allowed_owner: 'OpenVoxProject'
+      base-branch: ${{ github.event.inputs.base-branch }}
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      github_pat: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
+      ssh_private_key: ${{ secrets.OPENVOXBOT_SSH_PRIVATE_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: 'Release'
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to be released.'
+        required: false
+        default: ''
+        type: string
+      base-branch:
+        description: 'The branch where we do this release.'
+        required: false
+        default: ''
+        type: string
+
+permissions: {}
+
+jobs:
+  release:
+    uses: OpenVoxProject/shared-actions/.github/workflows/release.yml@main
+    with:
+      allowed_owner: 'OpenVoxProject'
+      base-branch: ${{ github.event.inputs.base-branch }}
+      version: ${{ github.event.inputs.version }}
+    secrets:
+      github_pat: ${{ secrets.OPENVOXBOT_COMMIT_AND_PRS }}
+      ssh_private_key: ${{ secrets.OPENVOXBOT_SSH_PRIVATE_KEY }}

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @puppetlabs/skeletor

--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,11 @@ group(:test) do
   gem "rubocop-rake", require: false
 end
 
+group(:release, optional: true) do
+  gem 'faraday-retry', '~> 2.1', require: false
+  gem 'github_changelog_generator', '~> 1.16.4', require: false
+end
+
 group(:packaging) do
   gem 'packaging', '~> 0.105'
 end

--- a/README.md
+++ b/README.md
@@ -3,47 +3,53 @@
 [![Windows Status](https://github.com/puppetlabs/bolt/workflows/Windows/badge.svg?branch=main)](https://github.com/puppetlabs/bolt/actions)
 [![Version](https://img.shields.io/github/v/tag/puppetlabs/bolt?label=version)](./CHANGELOG.md)
 [![Platforms](https://img.shields.io/badge/platforms-linux%20%7C%20windows%20%7C%20macos-lightgrey)](./documentation/bolt_installing.md)
-[![License](https://img.shields.io/github/license/puppetlabs/bolt)](./LICENSE)
+[![License](https://img.shields.io/github/license/OpenVoxProject/openbolt)](./LICENSE)
 
 <p align="center">
   <img src="resources/bolt-logo-dark.png" width="50%" alt="bolt logo"/>
 </p>
 
-Bolt is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure. Use Bolt to automate tasks that you perform on an as-needed basis or as part of a greater orchestration workflow. For example, you can use Bolt to patch and update systems, troubleshoot servers, deploy applications, or stop and restart services. Bolt can be installed on your local workstation and connects directly to remote targets with SSH or WinRM, so you are not required to install any agent software.
+OpenBolt is an open source orchestration tool that automates the manual work it takes to maintain your infrastructure. Use OpenBolt to automate tasks that you perform on an as-needed basis or as part of a greater orchestration workflow. For example, you can use OpenBolt to patch and update systems, troubleshoot servers, deploy applications, or stop and restart services. OpenBolt can be installed on your local workstation and connects directly to remote targets with SSH or WinRM, so you are not required to install any agent software.
+
+OpenBolt is a community implementation of [Puppet Bolt](https://github.com/puppetlabs/bolt).
 
 ### Bring order to the chaos with orchestration
 
-Run simple plans to rid yourself of the headaches of orchestrating complex workflows. Create and share Bolt plans to easily expand across your application stack.
+Run simple plans to rid yourself of the headaches of orchestrating complex workflows. Create and share OpenBolt plans to easily expand across your application stack.
 
 ### Use what you have to automate simple tasks or complex workflows
 
 Get going with your existing scripts and plans, including YAML, PowerShell, Bash, Python or Ruby, or reuse content from the [Puppet Forge](https://forge.puppet.com).
 
-### Get up and running with Bolt even faster
+### Documentation
 
-Speed up your Bolt knowledge with a step-by-step introduction to basic Bolt functionality with our [getting started guide](https://puppet.com/docs/bolt/latest/getting_started_with_bolt.html) and [self-paced training](https://puppet.com/learning-training/kits/intro-to-bolt).
+OpenBolt's documentation can be found under [documentation](./documentation). See also the [Puppet Bolt Docs site](https://help.puppet.com/bolt/current/topics/bolt.htm)
 
-More information and documentation is available on the [Bolt website](https://puppet.com/docs/bolt/latest/bolt.html).
+At the time of writing, the OpenVoxProject does not have a documentation website.
+But your help is very welcome!
+Reach out to the [Documentation Special Interest Group](https://github.com/voxpupuli/community-triage/wiki/SIG.Documentation) if you want to help.
+
+### Learning Resources
+
+- Puppet Bolt [getting started guide](https://puppet.com/docs/bolt/latest/getting_started_with_bolt.html)
+- Puppet Bolt [self-paced training](https://puppet.com/learning-training/kits/intro-to-bolt).
 
 ## Supported platforms
 
-Bolt can be installed on Linux, Windows, and macOS. For complete installation details, see the [installation docs](./documentation/bolt_installing.md).
+OpenBolt can be installed on Linux, Windows, and macOS. For complete installation details, see the [installation docs](./documentation/bolt_installing.md).
 
-For alternate installation methods and running from source code, see our [contributing guidelines](https://github.com/puppetlabs/bolt/blob/main/CONTRIBUTING.md).
+For alternate installation methods and running from source code, see our [contributing guidelines](https://github.com/OpenVoxProject/openbolt/blob/main/CONTRIBUTING.md).
 
 ## Getting help
 
-Join [#bolt](https://slack.puppet.com/) on the Puppet Community slack to chat with Bolt developers and the community.
+Join #bolt on the Vox Pupuli slack to chat with OpenBolt developers and the community.
 
 ## Contributing
 
-We welcome error reports and pull requests to Bolt. See our [contributing guidelines](./CONTRIBUTING.md) for how to help.
-
-## Kudos
-
-Thank you to [Marcin Bunsch](https://github.com/marcinbunsch) for allowing Puppet to use the `bolt` gem name.
+We welcome error reports and pull requests to OpenBolt. See our [contributing guidelines](./CONTRIBUTING.md) for how to help.
 
 ## License
 
-Bolt is available as open source under the terms of the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) license.
-
+See [LICENSE](LICENSE) file.
+OpenBolt is licensed by the OpenVox Project as a community maintained implementation of Bolt.
+The OpenVox Project can be contacted at: openvox@voxpupuli.org.

--- a/lib/bolt/applicator.rb
+++ b/lib/bolt/applicator.rb
@@ -32,7 +32,7 @@ module Bolt
     end
 
     private def libexec
-      @libexec ||= File.join(Gem::Specification.find_by_name('bolt').gem_dir, 'libexec')
+      @libexec ||= File.join(Gem::Specification.find_by_name('openbolt').gem_dir, 'libexec')
     end
 
     def custom_facts_task

--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -6,14 +6,14 @@ $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'bolt/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = "bolt"
+  spec.name          = "openbolt"
   spec.version       = Bolt::VERSION
-  spec.authors       = ["Puppet"]
-  spec.email         = ["puppet@puppet.com"]
+  spec.authors       = ['OpenVox Project']
+  spec.email         = ['openvox@voxpupuli.org']
 
   spec.summary       = "Execute commands remotely over SSH and WinRM"
   spec.description   = "Execute commands remotely over SSH and WinRM"
-  spec.homepage      = "https://github.com/puppetlabs/bolt"
+  spec.homepage      = 'https://github.com/OpenVoxProject/openbolt/'
   spec.license       = "Apache-2.0"
   spec.files         = Dir['exe/*'] +
                        Dir['lib/**/*.rb'] +


### PR DESCRIPTION
- rename gemspec file
- update gem version string in gemspec and version.rb to `5.0.0-alpha.0`
- add vox rake task for version bump and modify to allow for semver rubygem prerelease version strings
- add github_changelog_generator gem to Gemfile in the optional release group
- update the project README (have I replaced too many instances of ‘Bolt’ with ‘OpenBolt’?
- update github actions workflows etc to enable gem release and publish
