### PR TITLE
fix json gem to 2.12.x until allow_duplicate_key is added

### DIFF
--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -49,6 +49,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "concurrent-ruby", "~> 1.0"
   spec.add_dependency "ffi", ">= 1.9.25", "< 2.0.0"
   spec.add_dependency "hiera-eyaml", "~> 3"
+  spec.add_dependency "json", "~> 2.12.0"
   spec.add_dependency "jwt", "~> 2.2"
   spec.add_dependency "logging", "~> 2.2"
   spec.add_dependency "minitar", "~> 0.6"


### PR DESCRIPTION
This is to address an overabundance of the following message when running integration tests:

```
/home/runner/work/openbolt/openbolt/vendor/bundle/ruby/3.2.0/gems/json-2.13.0/lib/json/common.rb:338: warning: detected duplicate keys in JSON object. This will raise an error in json 3.0 unless enabled via `allow_duplicate_key: true` at line 1 column 1
```

If duplicate keys are valid for bolt’s integration tests then the better fix will presumably be to add `allow_duplicate_key: true` to json parser options. This is a short term measure to aid debugging of tests (noise reduction).  

See https://github.com/ruby/json/commit/06f00a42e8841cb768bf78514cf49b0d8cd63c27
