### PR TITLE
remove puppet 6 from integration specs

### DIFF
--- a/spec/docker-compose.yml
+++ b/spec/docker-compose.yml
@@ -6,15 +6,6 @@ services:
     ports:
       - "20022:22"
 
-  puppet_6_node:
-    build:
-      context: .
-      args:
-        PUPPET_COLLECTION: puppet6
-    container_name: puppet_6_node
-    ports:
-      - "20024:22"
-
   puppet_7_node:
     build:
       context: .

--- a/spec/fixtures/inventory/docker.yaml
+++ b/spec/fixtures/inventory/docker.yaml
@@ -8,10 +8,10 @@ groups:
     config:
       ssh:
         port: 20022
-  - name: puppet_6_node
+  - name: puppet_7_node
     config:
       ssh:
-        port: 20024
+        port: 20025
   config:
     ssh:
       host: localhost

--- a/spec/integration/apply_spec.rb
+++ b/spec/integration/apply_spec.rb
@@ -218,9 +218,8 @@ describe 'apply', apply: true do
           end
         end
 
-        # Run on puppet_6_node and puppet_7_node only, as deferred requires >= 6.
         it 'applies the deferred type' do
-          result = run_cli_json(%w[plan run basic::defer -t puppet_6_node,puppet_7_node], project: project)
+          result = run_cli_json(%w[plan run basic::defer -t puppet_7_node], project: project)
           expect(result).not_to include('kind')
           expect(result[0]['status']).to eq('success')
           resources = result[0]['value']['report']['resource_statuses']

--- a/spec/integration/device_spec.rb
+++ b/spec/integration/device_spec.rb
@@ -28,7 +28,7 @@ describe "devices" do
               'transport' => 'remote',
               'remote' => {
                 'remote-transport' => 'fake',
-                'run-on' => 'puppet_6_node',
+                'run-on' => 'puppet_7_node',
                 'path' => device_path
               }
             }
@@ -56,7 +56,7 @@ describe "devices" do
       end
     end
 
-    context "when running against puppet 6" do
+    context "when running against puppet 7" do
       it 'runs a plan that collects facts' do
         results = run_cli_json(%w[plan run device_test::facts -t device_targets], project: @project)
 
@@ -77,7 +77,7 @@ describe "devices" do
         expect(results).not_to include('kind')
         expect(results.dig(0, 'value', 'report', 'resource_statuses')).to include('Fake_device[key1]')
 
-        content = run_cli_json(['command', 'run', "cat '#{device_path}'", '-t', 'puppet_6_node'], project: @project)
+        content = run_cli_json(['command', 'run', "cat '#{device_path}'", '-t', 'puppet_7_node'], project: @project)
 
         expect(content.dig('items', 0, 'value', 'stdout')).to eq({ key1: 'val1' }.to_json)
 

--- a/spec/integration/parallel_spec.rb
+++ b/spec/integration/parallel_spec.rb
@@ -246,7 +246,7 @@ Undef:}
                           { "action" => "run_task",
                             "object" => "error::fail",
                             "result_set" =>
-                          [{ "target" => 'puppet_6_node',
+                          [{ "target" => 'puppet_7_node',
                              "action" => "task",
                              "object" => "error::fail",
                              "status" => "failure",

--- a/spec/lib/bolt_spec/conn.rb
+++ b/spec/lib/bolt_spec/conn.rb
@@ -92,10 +92,6 @@ module BoltSpec
                 'name' => 'nix_agents',
                 'targets' => [
                   {
-                    'name' => 'puppet_6_node',
-                    'config' => { 'ssh' => { 'port' => 20024 } }
-                  },
-                  {
                     'name' => 'puppet_7_node',
                     'config' => { 'ssh' => { 'port' => 20025 } }
                   }


### PR DESCRIPTION
This fixes nearly all of the tests by dropping support for puppet 6. 

Many tests are still using puppet 7 and a separate effort will need to shift them to openvox 8. 

There are 4 specs still failing in Linux / Integration (though one is addressed by #27 ) and 1 spec failing in Windows / Integration. It’s possible some of these specs need updating to cater for the newer version of puppet or other dependencies. 

