### PR TITLE
Fix bumping openbolt version

### DIFF
--- a/rakelib/vox.rake
+++ b/rakelib/vox.rake
@@ -8,23 +8,15 @@ namespace :vox do
     unless Gem::Version.correct?(version)
       abort "#{version} does not appear to be a valid version string in x.y.z format"
     end
-    # Update lib/bolt/version.rb and openbolt.gemspec
+    # Update lib/bolt/version.rb
     puts "Setting version to #{version}"
 
     data = File.read('lib/bolt/version.rb')
-    new_data = data.sub(/VERSION = '\d+\.\d+\.\d+(-\w+(\..*)?)?'/, "VERSION = '#{version}'")
+    new_data = data.sub(/VERSION = '[^']+'/, "VERSION = '#{version}'")
     if data == new_data
       warn 'Failed to update version in lib/bolt/version.rb'
     else
       File.write('lib/bolt/version.rb', new_data)
-    end
-
-    data = File.read('openbolt.gemspec')
-    new_data = data.sub(/(spec.version *=) '\d+\.\d+\.\d+(-\w+(\.\w+)?)?'/, "\\1 '#{version}'")
-    if data == new_data
-      warn 'Failed to update version in openbolt.gemspec'
-    else
-      File.write('openbolt.gemspec', new_data)
     end
   end
 end


### PR DESCRIPTION
The gemspec seems to have been using the version from Bolt::VERSION
since a long time, no need to update it when releasing a new version
(probably some copy-pasta).

Be more tolerant on what can be found in the version, as we incorrectly
released 5.0.0.rc1 instead of 5.0.0-rc1.  The version string is not
expected to contain `'` char, so it is probably enough to capture what
is in the quotes.
