### PR TITLE
add rspec github annotations formatter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group(:test) do
   gem "beaker-hostgenerator"
   gem "mocha", '~> 1.4.0'
   gem "rack-test", '~> 1.0'
+  gem 'rspec-github', require: false
 end
 
 group(:release, optional: true) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,11 @@ RSpec.configure do |config|
   # in a group (or even an individual test) by specifying
   # `:reset_puppet_settings' metadata on the group/test
   config.include_context 'reset puppet settings', :reset_puppet_settings
+
+  # Use the GitHub Annotations formatter for CI
+  if ENV['GITHUB_ACTIONS'] == 'true'
+    require 'rspec/github'
+    config.add_formatter 'progress'
+    config.add_formatter RSpec::Github::Formatter
+  end
 end


### PR DESCRIPTION
This adds rspec-gibhub annotations formatter as second rspec formatter when running under github actions. progress formatter is retained as it gives stack traces on errors. 

This allows surfacing of errors on the summary screen avoiding the need to drill into the log (however that will still be useful to get stack traces).

On the summary screen, before: 

<img width="1197" height="243" alt="bolt progress only formatter annotations" src="https://github.com/user-attachments/assets/ac513f99-80e3-43a0-9cec-5c2ed3bedcf0" />

after: 

<img width="1195" height="510" alt="bolt github actions formatter annotations" src="https://github.com/user-attachments/assets/c473009a-d3a3-4027-9c2b-88165412e26c" />

On the test output details view before: 

<img width="1165" height="1244" alt="bolt progress only formatter log" src="https://github.com/user-attachments/assets/be6b40c1-89aa-4a2e-820f-f64b41d18371" />

after: 

<img width="1165" height="1263" alt="bolt github actions formatter log" src="https://github.com/user-attachments/assets/3ca41637-ce80-4d91-8de1-0a3abc80ac13" />

