### PR TITLE
CI: Cleanup linux integration tests

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,18 +1,11 @@
+---
 name: Apply
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/apply.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/bolt_spec.yaml
+++ b/.github/workflows/bolt_spec.yaml
@@ -1,19 +1,12 @@
+---
+
 name: BoltSpec
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/bolt_spec.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - lib/bolt_spec/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/docker_transport.yaml
+++ b/.github/workflows/docker_transport.yaml
@@ -1,3 +1,4 @@
+---
 name: Docker transport
 
 on:

--- a/.github/workflows/linux.yaml
+++ b/.github/workflows/linux.yaml
@@ -1,18 +1,11 @@
+---
 name: Linux
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/linux.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/modules.yaml
+++ b/.github/workflows/modules.yaml
@@ -1,18 +1,11 @@
+---
 name: Modules
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/modules.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - bolt_spec_spec/**
-      - lib/bolt/**
-      - modules/**
-      - rakelib/tests.rake
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/pwsh.yaml
+++ b/.github/workflows/pwsh.yaml
@@ -1,13 +1,11 @@
+---
 name: pwsh
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/pwsh.yaml
-      - pwsh_module/*
-      - lib/bolt/bolt_option_parser.rb
-      - rakelib/pwsh.rake
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/schemas.yaml
+++ b/.github/workflows/schemas.yaml
@@ -1,14 +1,11 @@
+---
 name: Schemas
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - lib/bolt/config/options.rb
-      - lib/bolt/config/transport/**
-      - lib/bolt/inventory/options.rb
-      - rakelib/schemas.rake
-      - schemas/*.json
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/ssh_transport.yaml
+++ b/.github/workflows/ssh_transport.yaml
@@ -1,18 +1,11 @@
+---
 name: SSH Transport
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/ssh_transport.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/.github/workflows/windows.yaml
+++ b/.github/workflows/windows.yaml
@@ -2,18 +2,10 @@
 name: Windows
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/windows.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 env:
   BOLT_WINRM_USER: roddypiper

--- a/.github/workflows/winrm_transport.yaml
+++ b/.github/workflows/winrm_transport.yaml
@@ -1,18 +1,11 @@
+---
 name: WinRM Transport
 
 on:
-  pull_request:
-    types: [opened, reopened, edited, synchronize]
-    paths:
-      - .github/workflows/winrm_transport.yaml
-      - bolt.gemspec
-      - Gemfile
-      - Puppetfile
-      - bolt-modules/**
-      - lib/bolt/**
-      - libexec/**
-      - rakelib/tests.rake
-      - spec/**
+  pull_request: {}
+  push:
+    branches:
+      - main
 
 permissions:
   contents: read

--- a/lib/bolt/version.rb
+++ b/lib/bolt/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Bolt
-  VERSION = '5.0.0-rc2'
+  VERSION = '5.1.0'
 end

--- a/openbolt.gemspec
+++ b/openbolt.gemspec
@@ -61,7 +61,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "puppetfile-resolver", ">= 0.6.2", "< 1.0"
   spec.add_dependency "puppet-resource_api", ">= 1.8.1"
   spec.add_dependency "r10k", ">= 3.10", "< 5"
-  spec.add_dependency "ruby_smb", ">= 1.0", "< 4.0.0"
+  spec.add_dependency "ruby_smb", "~> 1.0"
   spec.add_dependency "terminal-table", "~> 3.0"
   spec.add_dependency "winrm", "~> 2.0"
   spec.add_dependency "winrm-fs", "~> 1.3"

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -71,9 +71,14 @@ Describe "test bolt command syntax" {
     }
 
     It "has correct number of parameters" {
-      ($command.Parameters.Values | Where-Object {
-        $_.name -notin $common
-      } | measure-object).Count | Should -Be 35
+      $customParams = $command.Parameters.Values | Where-Object {
+        $_.Name -notin $common
+      }
+
+      Write-Host "Custom parameters:"
+      $customParams | ForEach-Object { Write-Host " - $($_.Name)" }
+
+      ($customParams | Measure-Object).Count | Should -Be 35
     }
   }
 

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -14,7 +14,7 @@ BeforeAll {
   $common = @(
     'Version', 'Debug', 'ErrorAction', 'ErrorVariable', 'InformationAction',
     'InformationVariable', 'OutBuffer',  'OutVariable', 'PipelineVariable',
-    'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif'
+    'Verbose', 'WarningAction', 'WarningVariable', 'Confirm', 'Whatif', 'ProgressAction'
   )
 }
 

--- a/pwsh_module/command.tests.ps1
+++ b/pwsh_module/command.tests.ps1
@@ -71,14 +71,9 @@ Describe "test bolt command syntax" {
     }
 
     It "has correct number of parameters" {
-      $customParams = $command.Parameters.Values | Where-Object {
-        $_.Name -notin $common
-      }
-
-      Write-Host "Custom parameters:"
-      $customParams | ForEach-Object { Write-Host " - $($_.Name)" }
-
-      ($customParams | Measure-Object).Count | Should -Be 35
+      ($command.Parameters.Values | Where-Object {
+        $_.name -notin $common
+      } | measure-object).Count | Should -Be 35
     }
   }
 

--- a/spec/integration/container_spec.rb
+++ b/spec/integration/container_spec.rb
@@ -38,7 +38,7 @@ describe 'plans', bash: true do
       users = result.map do |hash|
         hash.dig('value', 'report', 'resource_statuses').keys
       end.flatten
-      expect(users).to eq(["Notify[root\n]", "Notify[root\n]"])
+      expect(users).to eq(["Notify[root\n]"])
     end
   end
 end

--- a/spec/integration/transport/local_spec.rb
+++ b/spec/integration/transport/local_spec.rb
@@ -83,7 +83,7 @@ describe Bolt::Transport::Local do
           expect(runner.upload(target, file.path, dest, run_as: user).message).to match(/Uploaded/)
           expect(runner.run_command(target, "cat #{dest}", run_as: user)['stdout']).to eq(contents)
           expect(runner.run_command(target, "stat -c %U #{dest}", run_as:  user)['stdout'].chomp).to eq(user)
-          expect(runner.run_command(target, "stat -c %G #{dest}", run_as:  user)['stdout'].chomp).to eq('docker')
+          expect(runner.run_command(target, "stat -c %G #{dest}", run_as:  user)['stdout'].chomp).to eq('runner')
         end
 
         runner.run_command(target, "rm #{dest}", sudoable: true, run_as: user)


### PR DESCRIPTION
This fixes a regression introduced in
https://github.com/OpenVoxProject/openbolt/commit/573cdb5454f360306bd5ebd6aa88256724f07a3c /
https://github.com/OpenVoxProject/openbolt/pull/28. We run bolt on a couple of containers and valid the resultset. A Puppet 6 container was removed, but the test still expected the result from that. This wasn't noticed in CI, because the tests were only executed when specific files changed, and that wasn't triggered in this specific case. We cleaned up CI and all jobs now run always.

---

This PR includes #54 #55 #56 #57 #58