### PR TITLE
Revert "CI: Move apply tests to central workflow"

### DIFF
--- a/.github/workflows/apply.yaml
+++ b/.github/workflows/apply.yaml
@@ -1,0 +1,55 @@
+---
+name: Apply
+
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+env:
+  BOLT_WINRM_USER: roddypiper
+  BOLT_WINRM_HOST: localhost
+  BOLT_WINRM_PORT: 5985
+  BOLT_WINRM_SSL_PORT: 5986
+  BOLT_WINRM_SMB_PORT: 445
+
+jobs:
+  tests:
+    name: Tests
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, windows-latest]
+        ruby: [3.2]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Cache modules
+        id: modules
+        uses: actions/cache@v4
+        with:
+          path: modules
+          key: ${{ runner.os }}-modules-${{ hashFiles('**/Puppetfile') }}
+      - name: Install modules
+        if: steps.modules.outputs.cache-hit != 'true'
+        run: bundle exec r10k puppetfile install
+      - if: matrix.os == 'ubuntu-22.04'
+        uses: ./.github/actions/sudo_setup
+      - if: matrix.os == 'windows-latest'
+        uses: ./.github/actions/windows_agent_setup
+      - if: matrix.os == 'ubuntu-22.04'
+        name: Run tests
+        run: bundle exec rake ci:apply:linux
+      - if: matrix.os == 'windows-latest'
+        name: Run tests
+        run: bundle exec rake ci:apply:windows

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -10,14 +10,6 @@ on:
 permissions:
   contents: read
 
-# those variables are used by the majority of jobs and we don't want to repeat them in each job
-env:
-  BOLT_WINRM_USER: roddypiper
-  BOLT_WINRM_HOST: localhost
-  BOLT_WINRM_PORT: 5985
-  BOLT_WINRM_SSL_PORT: 5986
-  BOLT_WINRM_SMB_PORT: 445
-
 jobs:
   rubocop_and_matrix:
     runs-on: ubuntu-24.04
@@ -108,6 +100,12 @@ jobs:
     needs:
     - rubocop_and_matrix
     - cache_modules
+    env:
+      BOLT_WINRM_USER: roddypiper
+      BOLT_WINRM_HOST: localhost
+      BOLT_WINRM_PORT: 5985
+      BOLT_WINRM_SSL_PORT: 5986
+      BOLT_WINRM_SMB_PORT: 445
     strategy:
       fail-fast: false
       matrix:
@@ -143,6 +141,12 @@ jobs:
     needs:
       - rubocop_and_matrix
       - cache_modules
+    env:
+      BOLT_WINRM_USER: roddypiper
+      BOLT_WINRM_HOST: localhost
+      BOLT_WINRM_PORT: 5985
+      BOLT_WINRM_SSL_PORT: 5986
+      BOLT_WINRM_SMB_PORT: 445
     name: WinRM Transport
     runs-on: windows-latest
     strategy:
@@ -169,43 +173,6 @@ jobs:
           Set-ActiveRubyFromPuppet
       - name: WinRM transport tests
         run: bundle exec rake ci:winrm_transport
-
-  apply:
-    name: bolt apply
-    needs:
-      - rubocop_and_matrix
-      - cache_modules
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-24.04, windows-2025]
-        ruby: ${{ fromJSON(needs.rubocop_and_matrix.outputs.ruby) }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-      - name: Setup Ruby
-        uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
-      - name: Cache modules
-        id: modules
-        uses: actions/cache@v4
-        with:
-          path: modules
-          key: ${{ runner.os }}-modules-${{ hashFiles('**/Puppetfile') }}
-      - if: matrix.os == 'ubuntu-22.04'
-        uses: ./.github/actions/sudo_setup
-      - if: matrix.os == 'windows-latest'
-        uses: ./.github/actions/windows_agent_setup
-      - if: matrix.os == 'ubuntu-22.04'
-        name: Run tests
-        run: bundle exec rake ci:apply:linux
-      - if: matrix.os == 'windows-latest'
-        name: Run tests
-        run: bundle exec rake ci:apply:windows
-
   tests:
     needs:
       - rubocop_and_matrix
@@ -214,7 +181,6 @@ jobs:
       - run-dita
       - local_transports
       - winrm_transport
-      - apply
     runs-on: ubuntu-24.04
     name: Test suite
     steps:


### PR DESCRIPTION
Reverts OpenVoxProject/openbolt#66

I would like to know if tests pass when I revert this. Related: https://github.com/OpenVoxProject/openbolt/pull/68