### PR TITLE
Ruby error: Adjust pattern matching to newer ruby/rubygems

### DIFF
--- a/spec/integration/apply_error_spec.rb
+++ b/spec/integration/apply_error_spec.rb
@@ -32,7 +32,7 @@ describe "errors gracefully attempting to apply a manifest block", apply: true d
       with_tempfile_containing('site', 'load_error()', '.pp') do |tempfile|
         run_cli(%W[apply #{tempfile.path} --run-as root --sudo-password #{password}] + config_flags)
         logs = @log_output.readlines
-        expect(logs).to include(/`require': cannot load such file -- fake \(LoadError\)/)
+        expect(logs).to include(/cannot load such file -- fake \(LoadError\)/)
         expect(logs).to include(/Something's gone terribly wrong! STDERR is logged/)
       end
     end


### PR DESCRIPTION
In the past, we matched for :

```
`require': cannot load such file -- fake (LoadError)
```

The error now is:

```
'Kernel.require': cannot load such file -- fake (LoadError)
```

I'm not sure if this is a Ruby 3.4.X change, or something within rubygems.