### PR TITLE
Pass Forge auth token to module resolution

### DIFF
--- a/lib/bolt/module_installer/resolver.rb
+++ b/lib/bolt/module_installer/resolver.rb
@@ -63,6 +63,15 @@ module Bolt
           obj.forge.proxy     = config.dig('forge', 'proxy') || config.dig('proxy')
           obj.git.proxy       = config.dig('proxy')
           obj.forge.forge_api = config.dig('forge', 'baseurl')
+          auth_token = config.dig('forge', 'authorization_token')
+          next if auth_token.nil?
+
+          if obj.forge.respond_to?(:token)
+            obj.forge.token = auth_token
+          else
+            logger = Bolt::Logger.logger(self)
+            logger.warn("Unable to authenticate for metadata retrieval when using puppetfile-resolver <= 0.6.3")
+          end
         end
       end
 


### PR DESCRIPTION
If the user has configured an authentication token for a Forge API-compatible endpoint, and if the user is running a version of puppetfile-resolver which supports receiving configuration for an authentication token, then pass it. Otherwise, warn the user that the metadata retrieval will not be authenticated.

This is required for JFrog Artifactory Puppet repositories starting with Artifactory Self-Managed 7.161.16 or Artifactory SaaS 7.164.0, which resolved CVE-2026-66379.
